### PR TITLE
Add f-AnoGAN for the MVTec Anomaly Detection Dataset

### DIFF
--- a/mvtec_ad/model.py
+++ b/mvtec_ad/model.py
@@ -1,0 +1,102 @@
+import torch.nn as nn
+
+
+"""
+The code is:
+Copyright (c) 2018 Erik Linder-Norén
+Licensed under MIT
+(https://github.com/eriklindernoren/PyTorch-GAN/blob/master/LICENSE)
+"""
+
+
+class Generator(nn.Module):
+    def __init__(self, opt):
+        super().__init__()
+
+        self.init_size = opt.img_size // 4
+        self.l1 = nn.Sequential(nn.Linear(opt.latent_dim,
+                                128 * self.init_size ** 2))
+
+        self.conv_blocks = nn.Sequential(
+            nn.BatchNorm2d(128),
+            nn.Upsample(scale_factor=2),
+            nn.Conv2d(128, 128, 3, stride=1, padding=1),
+            nn.BatchNorm2d(128, 0.8),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Upsample(scale_factor=2),
+            nn.Conv2d(128, 64, 3, stride=1, padding=1),
+            nn.BatchNorm2d(64, 0.8),
+            nn.LeakyReLU(0.2, inplace=True),
+            nn.Conv2d(64, opt.channels, 3, stride=1, padding=1),
+            nn.Tanh(),
+        )
+
+    def forward(self, z):
+        out = self.l1(z)
+        out = out.view(out.shape[0], 128, self.init_size, self.init_size)
+        img = self.conv_blocks(out)
+        return img
+
+
+class Discriminator(nn.Module):
+    def __init__(self, opt):
+        super().__init__()
+
+        def discriminator_block(in_filters, out_filters, bn=True):
+            block = [nn.Conv2d(in_filters, out_filters, 3, 2, 1),
+                     nn.LeakyReLU(0.2, inplace=True), nn.Dropout2d(0.25)]
+            if bn:
+                block.append(nn.BatchNorm2d(out_filters, 0.8))
+            return block
+
+        self.model = nn.Sequential(
+            *discriminator_block(opt.channels, 16, bn=False),
+            *discriminator_block(16, 32),
+            *discriminator_block(32, 64),
+            *discriminator_block(64, 128),
+        )
+
+        # The height and width of downsampled image
+        ds_size = opt.img_size // 2 ** 4
+        self.adv_layer = nn.Sequential(nn.Linear(128 * ds_size ** 2, 1))
+
+    def forward(self, img):
+        features = self.forward_features(img)
+        validity = self.adv_layer(features)
+        return validity
+
+    def forward_features(self, img):
+        features = self.model(img)
+        features = features.view(features.shape[0], -1)
+        return features
+
+
+class Encoder(nn.Module):
+    def __init__(self, opt):
+        super().__init__()
+
+        def encoder_block(in_filters, out_filters, bn=True):
+            block = [nn.Conv2d(in_filters, out_filters, 3, 2, 1),
+                     nn.LeakyReLU(0.2, inplace=True), nn.Dropout2d(0.25)]
+            if bn:
+                block.append(nn.BatchNorm2d(out_filters, 0.8))
+            return block
+
+        self.model = nn.Sequential(
+            *encoder_block(opt.channels, 16, bn=False),
+            *encoder_block(16, 32),
+            *encoder_block(32, 64),
+            *encoder_block(64, 128),
+        )
+
+        # The height and width of downsampled image
+        ds_size = opt.img_size // 2 ** 4
+        self.adv_layer = nn.Sequential(nn.Linear(128 * ds_size ** 2,
+                                                 opt.latent_dim),
+                                       nn.Tanh())
+
+    def forward(self, img):
+        features = self.model(img)
+        features = features.view(features.shape[0], -1)
+        validity = self.adv_layer(features)
+        return validity

--- a/mvtec_ad/test_anomaly_detection.py
+++ b/mvtec_ad/test_anomaly_detection.py
@@ -1,0 +1,68 @@
+import os
+import torch
+from torch.utils.data import DataLoader
+import torchvision.transforms as transforms
+from torchvision import datasets
+
+from fanogan.test_anomaly_detection import test_anomaly_detection
+
+from model import Generator, Discriminator, Encoder
+from tools import MVTecAD, MVTECAD_DATASET_NAMES
+
+
+def main(opt):
+    if type(opt.seed) is int:
+        torch.manual_seed(opt.seed)
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    mvtec_ad = MVTecAD()
+
+    if not os.path.isdir(opt.dataset_name) or opt.force_download:
+        mvtec_ad.download(opt.dataset_name)
+        mvtec_ad.extract(opt.dataset_name)
+
+    images = datasets.ImageFolder(f"./{opt.dataset_name}/test",
+                                  transform=transforms.Compose(
+                                    [transforms.Resize([opt.img_size]*2),
+                                     transforms.RandomHorizontalFlip(),
+                                     transforms.ToTensor(),
+                                     transforms.Normalize([0.5, 0.5, 0.5],
+                                                          [0.5, 0.5, 0.5])])
+                                  )
+    test_dataloader = DataLoader(images, batch_size=1, shuffle=False)
+
+    generator = Generator(opt)
+    discriminator = Discriminator(opt)
+    encoder = Encoder(opt)
+
+    test_anomaly_detection(opt, generator, discriminator, encoder,
+                           test_dataloader, device)
+
+
+"""
+The code below is:
+Copyright (c) 2018 Erik Linder-Norén
+Licensed under MIT
+(https://github.com/eriklindernoren/PyTorch-GAN/blob/master/LICENSE)
+"""
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dataset_name", type=str,
+                        choices=MVTECAD_DATASET_NAMES,
+                        help="name of MVTec Anomaly Detection Datasets")
+    parser.add_argument("--force_download", "-f", action="store_true",
+                        help="flag of force download")
+    parser.add_argument("--latent_dim", type=int, default=100,
+                        help="dimensionality of the latent space")
+    parser.add_argument("--img_size", type=int, default=64,
+                        help="size of each image dimension")
+    parser.add_argument("--channels", type=int, default=3,
+                        help="number of image channels")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="value of a random seed")
+    opt = parser.parse_args()
+
+    main(opt)

--- a/mvtec_ad/tools.py
+++ b/mvtec_ad/tools.py
@@ -1,0 +1,41 @@
+from ftplib import FTP
+import tarfile
+
+
+MVTECAD_DATASET_NAMES = ["bottle", "cable", "capsule", "carpet", "grid",
+                         "hazelnut", "leather", "metal_nut",
+                         "mvtec_anomaly_detection", "pill", "screw",
+                         "tile", "toothbrush", "transistor", "wood", "zipper"]
+
+
+class MVTecAD:
+    """Download MVTec Anomaly Detection Dataset by FTP.
+
+    Notes
+    -----
+    `mvtec_anomaly_detection` is the whole dataset.
+
+    See Also
+    --------
+    https://www.mvtec.com/company/research/datasets/mvtec-ad/
+    """
+    def __init__(self):
+        self.datasets = MVTECAD_DATASET_NAMES
+
+    def download(self, dataset_name):
+        dataset_name = dataset_name.lower()
+        if dataset_name not in self.datasets:
+            raise ValueError(f"The dataset called `{dataset_name}` "
+                             "is not exist")
+
+        with FTP("ftp.softronics.ch") as ftp:
+            ftp.login(user="guest", passwd="GU.205dldo")
+            ftp.cwd("mvtec_anomaly_detection")
+
+            with open(f"{dataset_name}.tar.xz", "wb") as f:
+                ftp.retrbinary(f"RETR {dataset_name}.tar.xz", f.write)
+
+    def extract(self, dataset_name, save_path="."):
+        dataset_name = dataset_name.lower()
+        with tarfile.open(f"{dataset_name}.tar.xz", "r:xz") as tf:
+            tf.extractall(path=save_path)

--- a/mvtec_ad/train_encoder_izif.py
+++ b/mvtec_ad/train_encoder_izif.py
@@ -1,0 +1,84 @@
+import os
+import torch
+from torch.utils.data import DataLoader
+import torchvision.transforms as transforms
+from torchvision import datasets
+
+from fanogan.train_encoder_izif import train_encoder_izif
+
+from model import Generator, Discriminator, Encoder
+from tools import MVTecAD, MVTECAD_DATASET_NAMES
+
+
+def main(opt):
+    if type(opt.seed) is int:
+        torch.manual_seed(opt.seed)
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    mvtec_ad = MVTecAD()
+
+    if not os.path.isdir(opt.dataset_name) or opt.force_download:
+        mvtec_ad.download(opt.dataset_name)
+        mvtec_ad.extract(opt.dataset_name)
+
+    images = datasets.ImageFolder(f"./{opt.dataset_name}/train",
+                                  transform=transforms.Compose(
+                                    [transforms.Resize([opt.img_size]*2),
+                                     transforms.RandomHorizontalFlip(),
+                                     transforms.ToTensor(),
+                                     transforms.Normalize([0.5, 0.5, 0.5],
+                                                          [0.5, 0.5, 0.5])])
+                                  )
+    train_dataloader = DataLoader(images, batch_size=opt.batch_size,
+                                  shuffle=True)
+
+    generator = Generator(opt)
+    discriminator = Discriminator(opt)
+    encoder = Encoder(opt)
+
+    train_encoder_izif(opt, generator, discriminator, encoder,
+                       train_dataloader, device)
+
+
+"""
+The code below is:
+Copyright (c) 2018 Erik Linder-Norén
+Licensed under MIT
+(https://github.com/eriklindernoren/PyTorch-GAN/blob/master/LICENSE)
+"""
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dataset_name", type=str,
+                        choices=MVTECAD_DATASET_NAMES,
+                        help="name of MVTec Anomaly Detection Datasets")
+    parser.add_argument("--force_download", "-f", action="store_true",
+                        help="flag of force download")
+    parser.add_argument("--n_epochs", type=int, default=200,
+                        help="number of epochs of training")
+    parser.add_argument("--batch_size", type=int, default=32,
+                        help="size of the batches")
+    parser.add_argument("--lr", type=float, default=0.0002,
+                        help="adam: learning rate")
+    parser.add_argument("--b1", type=float, default=0.5,
+                        help="adam: decay of first order momentum of gradient")
+    parser.add_argument("--b2", type=float, default=0.999,
+                        help="adam: decay of first order momentum of gradient")
+    parser.add_argument("--latent_dim", type=int, default=100,
+                        help="dimensionality of the latent space")
+    parser.add_argument("--img_size", type=int, default=64,
+                        help="size of each image dimension")
+    parser.add_argument("--channels", type=int, default=3,
+                        help="number of image channels")
+    parser.add_argument("--n_critic", type=int, default=5,
+                        help="number of training steps for "
+                             "discriminator per iter")
+    parser.add_argument("--sample_interval", type=int, default=400,
+                        help="interval betwen image samples")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="value of a random seed")
+    opt = parser.parse_args()
+
+    main(opt)

--- a/mvtec_ad/train_wgangp.py
+++ b/mvtec_ad/train_wgangp.py
@@ -1,0 +1,82 @@
+import os
+import torch
+from torch.utils.data import DataLoader
+import torchvision.transforms as transforms
+from torchvision import datasets
+
+from fanogan.train_wgangp import train_wgangp
+
+from model import Generator, Discriminator
+from tools import MVTecAD, MVTECAD_DATASET_NAMES
+
+
+def main(opt):
+    if type(opt.seed) is int:
+        torch.manual_seed(opt.seed)
+    device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+
+    mvtec_ad = MVTecAD()
+
+    if not os.path.isdir(opt.dataset_name) or opt.force_download:
+        mvtec_ad.download(opt.dataset_name)
+        mvtec_ad.extract(opt.dataset_name)
+
+    images = datasets.ImageFolder(f"./{opt.dataset_name}/train",
+                                  transform=transforms.Compose(
+                                    [transforms.Resize([opt.img_size]*2),
+                                     transforms.RandomHorizontalFlip(),
+                                     transforms.ToTensor(),
+                                     transforms.Normalize([0.5, 0.5, 0.5],
+                                                          [0.5, 0.5, 0.5])])
+                                  )
+    train_dataloader = DataLoader(images, batch_size=opt.batch_size,
+                                  shuffle=True)
+
+    generator = Generator(opt)
+    discriminator = Discriminator(opt)
+
+    train_wgangp(opt, generator, discriminator, train_dataloader, device)
+
+
+"""
+The code below is:
+Copyright (c) 2018 Erik Linder-Norén
+Licensed under MIT
+(https://github.com/eriklindernoren/PyTorch-GAN/blob/master/LICENSE)
+"""
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dataset_name", type=str,
+                        choices=MVTECAD_DATASET_NAMES,
+                        help="name of MVTec Anomaly Detection Datasets")
+    parser.add_argument("--force_download", "-f", action="store_true",
+                        help="flag of force download")
+    parser.add_argument("--n_epochs", type=int, default=300,
+                        help="number of epochs of training")
+    parser.add_argument("--batch_size", type=int, default=32,
+                        help="size of the batches")
+    parser.add_argument("--lr", type=float, default=0.0002,
+                        help="adam: learning rate")
+    parser.add_argument("--b1", type=float, default=0.5,
+                        help="adam: decay of first order momentum of gradient")
+    parser.add_argument("--b2", type=float, default=0.999,
+                        help="adam: decay of first order momentum of gradient")
+    parser.add_argument("--latent_dim", type=int, default=100,
+                        help="dimensionality of the latent space")
+    parser.add_argument("--img_size", type=int, default=64,
+                        help="size of each image dimension")
+    parser.add_argument("--channels", type=int, default=3,
+                        help="number of image channels")
+    parser.add_argument("--n_critic", type=int, default=5,
+                        help="number of training steps for "
+                             "discriminator per iter")
+    parser.add_argument("--sample_interval", type=int, default=400,
+                        help="interval betwen image samples")
+    parser.add_argument("--seed", type=int, default=None,
+                        help="value of a random seed")
+    opt = parser.parse_args()
+
+    main(opt)


### PR DESCRIPTION
This PR will be able to train and test eriklindernoren's DCGAN for the MVTec Anomaly Detection Dataset.

## Usage

### Change a directory

```bash
cd mvtec_ad
```

You can choose one item from datasets below.

`"bottle", "cable", "capsule", "carpet", "grid", "hazelnut", "leather", "metal_nut", "mvtec_anomaly_detection", "pill", "screw", "tile", "toothbrush", "transistor", "wood", "zipper"`.

For more information of datasets, see [MVTec Anomaly Detection Dataset (MVTec AD) - MVTec Software GmbH](https://www.mvtec.com/company/research/datasets/mvtec-ad/).

### Training Generator and Discriminator

```bash
python train_wgangp.py "bottle" --seed 1 --n_epochs 1000
```

### Training Encoder

```bash
python train_encoder_izif.py "bottle" --seed 1 --sample_interval 50 --n_epochs 100
```

### Test

```bash
python test_anomaly_detection.py "bottle" --seed 1
```


